### PR TITLE
Add further support for bedrock's `dyed` icon variant in the custom item API

### DIFF
--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/CustomItemBedrockOptions.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/CustomItemBedrockOptions.java
@@ -52,6 +52,15 @@ public interface CustomItemBedrockOptions {
     @Nullable String icon();
 
     /**
+     * Gets the item's dyed icon, When not present, the item's default {@code icon} texture is used
+     *
+     * @return the item's dyed icon
+     * @see CustomItemDefinition#dyedIcon()
+     * @since 2.10.1
+     */
+    @Nullable String dyedIcon();
+
+    /**
      * If the item is allowed to be put into the offhand. Defaults to true.
      *
      * @return true if the item is allowed to be used in the offhand, false otherwise
@@ -141,6 +150,17 @@ public interface CustomItemBedrockOptions {
          */
         @This
         Builder icon(@Nullable String icon);
+
+        /**
+         * Sets the item's icon.
+         *
+         * @param dyedIcon the item's icon
+         * @see CustomItemBedrockOptions#dyedIcon()
+         * @return this builder
+         * @since 2.9.3
+         */
+        @This
+        Builder dyedIcon(@Nullable String dyedIcon);
 
         /**
          * Sets if the item is allowed to be put into the offhand.

--- a/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/CustomItemDefinition.java
+++ b/api/src/main/java/org/geysermc/geyser/api/item/custom/v2/CustomItemDefinition.java
@@ -110,6 +110,17 @@ public interface CustomItemDefinition {
     String icon();
 
     /**
+     * The icon used for this item if it's marked as {@code dyeable}
+     *
+     * <p>If none is set in the item's Bedrock options, then the item's default icon is used.
+     *
+     * @return the icon shown to Bedrock players if the item is marked dyeable
+     * @see #icon()
+     * @since 2.10.1
+     */
+    String dyedIcon();
+
+    /**
      * The predicates that have to match for this item definition to be used. These predicates can access properties similar to the Java item model predicates.
      *
      * <p>When adding predicates, avoid chaining many predicates that use an OR expression - instead, set the {@link PredicateStrategy} of the definition to

--- a/core/src/main/java/org/geysermc/geyser/item/custom/GeyserCustomItemBedrockOptions.java
+++ b/core/src/main/java/org/geysermc/geyser/item/custom/GeyserCustomItemBedrockOptions.java
@@ -40,7 +40,7 @@ import java.util.Objects;
 import java.util.OptionalInt;
 import java.util.Set;
 
-public record GeyserCustomItemBedrockOptions(@Nullable String icon, boolean allowOffhand, boolean displayHandheld, int protectionValue,
+public record GeyserCustomItemBedrockOptions(@Nullable String icon, @Nullable String dyedIcon, boolean allowOffhand, boolean displayHandheld, int protectionValue,
                                              @NonNull CreativeCategory creativeCategory, @Nullable String creativeGroup, @NonNull Set<Identifier> tags,
                                              OptionalInt dyeable) implements CustomItemBedrockOptions {
 
@@ -58,6 +58,7 @@ public record GeyserCustomItemBedrockOptions(@Nullable String icon, boolean allo
 
     public static class Builder implements CustomItemBedrockOptions.Builder {
         private String icon = null;
+        private String dyedIcon = null;
         private boolean allowOffhand = true;
         private boolean displayHandheld = false;
         private int protectionValue = -1;
@@ -69,6 +70,12 @@ public record GeyserCustomItemBedrockOptions(@Nullable String icon, boolean allo
         @Override
         public Builder icon(@Nullable String icon) {
             this.icon = icon;
+            return this;
+        }
+
+        @Override
+        public Builder dyedIcon(@Nullable String dyedIcon) {
+            this.dyedIcon = dyedIcon;
             return this;
         }
 
@@ -130,7 +137,7 @@ public record GeyserCustomItemBedrockOptions(@Nullable String icon, boolean allo
 
         @Override
         public CustomItemBedrockOptions build() {
-            return new GeyserCustomItemBedrockOptions(icon, allowOffhand, displayHandheld, protectionValue,
+            return new GeyserCustomItemBedrockOptions(icon, dyedIcon, allowOffhand, displayHandheld, protectionValue,
                 creativeCategory, creativeGroup, Set.copyOf(tags), dyeableColor == null ? OptionalInt.empty() : OptionalInt.of(dyeableColor));
         }
     }

--- a/core/src/main/java/org/geysermc/geyser/item/custom/GeyserCustomItemDefinition.java
+++ b/core/src/main/java/org/geysermc/geyser/item/custom/GeyserCustomItemDefinition.java
@@ -57,6 +57,7 @@ public class GeyserCustomItemDefinition implements CustomItemDefinition {
     private final @NonNull String displayName;
     private final @NonNull Identifier model;
     private final @NonNull String icon;
+    private final @NonNull String dyedIcon;
     private final @NonNull List<MinecraftPredicate<? super ItemPredicateContext>> predicates;
     private final PredicateStrategy predicateStrategy;
     private final int priority;
@@ -77,6 +78,9 @@ public class GeyserCustomItemDefinition implements CustomItemDefinition {
 
         String setIcon = builder.bedrockOptions.icon();
         icon = setIcon == null ? bedrockIdentifier().toString().replaceAll(":", ".").replaceAll("/", "_") : setIcon;
+
+        String setDyedIcon = builder.bedrockOptions.dyedIcon();
+        dyedIcon = setDyedIcon == null ? icon : setDyedIcon;
 
         this.predicates = List.copyOf(builder.predicates);
         this.predicateStrategy = builder.predicateStrategy;
@@ -107,6 +111,11 @@ public class GeyserCustomItemDefinition implements CustomItemDefinition {
     @Override
     public @NonNull String icon() {
         return icon;
+    }
+
+    @Override
+    public @NonNull String dyedIcon() {
+        return dyedIcon;
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/geyser/registry/mappings/definition/SingleDefinitionReader.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/mappings/definition/SingleDefinitionReader.java
@@ -138,6 +138,7 @@ public class SingleDefinitionReader implements ItemDefinitionReader {
         if (bedrockOptions == null) {
             return;
         }
+        JsonElement dyeableObject = bedrockOptions.getAsJsonObject().get("dyeable");
 
         String[] context = {"bedrock options", baseContext};
         MappingsUtil.readIfPresent(bedrockOptions, "icon", builder::icon, NodeReader.NON_EMPTY_STRING, context);
@@ -147,7 +148,12 @@ public class SingleDefinitionReader implements ItemDefinitionReader {
         MappingsUtil.readIfPresent(bedrockOptions, "creative_category", builder::creativeCategory, NodeReader.CREATIVE_CATEGORY, context);
         MappingsUtil.readIfPresent(bedrockOptions, "creative_group", builder::creativeGroup, NodeReader.NON_EMPTY_STRING, context);
         MappingsUtil.readArrayIfPresent(bedrockOptions, "tags", tags -> builder.tags(new HashSet<>(tags)), NodeReader.IDENTIFIER, context);
-        MappingsUtil.readIfPresent(bedrockOptions, "dyeable", builder::dyeable, NodeReader.HEX_INT, context);
+
+        if (dyeableObject != null) {
+            // Defaults to white to keep the object dyeable even without a user-specified default_color.
+            builder.dyeable(MappingsUtil.readOrDefault(dyeableObject, "default_color", NodeReader.HEX_INT, 0xFFFFFF, context));
+            MappingsUtil.readIfPresent(dyeableObject, "dyed_icon", builder::dyedIcon, NodeReader.NON_EMPTY_STRING, context);
+        }
 
         definitionBuilder.bedrockOptions(builder);
     }

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/CustomItemRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/CustomItemRegistryPopulator.java
@@ -439,6 +439,7 @@ public class CustomItemRegistryPopulator {
             NbtMap iconMap = NbtMap.builder()
                 .putCompound("textures", NbtMap.builder()
                     .putString("default", definition.icon())
+                    .putString("dyed", definition.dyedIcon())
                     .build())
                 .build();
             itemProperties.putCompound("minecraft:icon", iconMap);


### PR DESCRIPTION
This PR includes the required code changes for the [dyed](https://wiki.bedrock.dev/items/item-components#icon-object) icon variant of bedrock's dyeable item.

The PR also changes data structure on mappings to use a component-based object (instead of simple hex integer) for bedrock_options, which now is written as follows:
```json
"bedrock_options": {
  "dyeable": {
    "default_color": "aceace"
    "dyed_icon": "cloth:tshirt_dyed"
  }
}
```
This is done to ensure all dyeable-related properties are grouped under a single object for better consistency.